### PR TITLE
Постраничный вывод и делегирование событий

### DIFF
--- a/src/pictures.js
+++ b/src/pictures.js
@@ -3,7 +3,6 @@ var filtersBlock = document.querySelector('.filters');
 var picturesContainer = document.querySelector('.pictures');
 var pictureTemplate = document.querySelector('#picture-template');
 var cloneElement;
-var imageLoadTimeout;
 
 var TIMEOUT = 10000; //устанавливаем таймаут 10 секунд
 
@@ -42,6 +41,8 @@ var getPictureElement = function(data, container) {
   var pictureItem = element.querySelector('img');
   pictureItem.width = 182;
   pictureItem.height = 182;
+
+  var imageLoadTimeout;
 
   pictureItem.onload = function() {
     clearTimeout(imageLoadTimeout);


### PR DESCRIPTION
Перепишите функцию вывода списка фотографий таким образом, чтобы она отрисовывала не все доступные изображения, а постранично:

Каждая страница состоит максимум из 12 фотографий (последняя может содержать меньше).

Сделайте так, чтобы функция могла работать в двух режимах: добавления страницы и перезаписи содержимого контейнера.

Добавьте обработчик события scroll у объекта window, который будет отображать следующую страницу с фотографиями, по достижении низа страницы.

Оптимизируйте обработчик события scroll с помощью таймаута, который срабатывает каждые 100 миллисекунд.

Перепишите функцию, которая устанавливает обработчики событий на клики по фильтрам с использованием делегирования.

После переключения фильтра, должна показываться первая страница (тут-то вам и пригодится режим перезаписи контейнера в функции вывода фотографий).

--
:boom: https://htmlacademy-javascript.github.io/28813-kekstagram/9/